### PR TITLE
feat: cardLocked metadata added.

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -276,6 +276,7 @@ RegisterNetEvent('qb-banking:createBankCard', function(pin)
     info.cardPin = tonumber(pin)
     info.cardActive = true
     info.cardType = selectedCard
+    info.cardLocked = false
 
     if selectedCard == "visa" then
         xPlayer.Functions.AddItem('visa', 1, nil, info)


### PR DESCRIPTION
**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

There is no `cardLocked` metadata associated with Visa or Mastercards items, despite it being a field in the database. This change should fix that. I will update [qb-atms](https://github.com/qbcore-framework/qb-atms) to reflect this change and add extra functionality to reflect a card being blocked.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **Yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
